### PR TITLE
Cache banana assets to prevent asset unloading

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ pub const BANANA_HEIGHT: f32 = 70.0;
 // occurs when you catch a banana at the top of the basket. The
 // other banana that has "just spawned" will disappear until the
 // next banana spawns. Should look into this more.
-pub const BANANA_SPAWN_TIMER_IN_SECONDS: f32 = 0.55;
+pub const BANANA_SPAWN_TIMER_IN_SECONDS: f32 = 0.5;
 pub const BANANA_SPEED: f32 = 800.0;
 
 pub const BOUND_SIZE: f32 = 120.0;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,10 +6,6 @@ use rand::prelude::*;
 
 pub const BASKET_WIDTH: f32 = 128.0;
 pub const BANANA_HEIGHT: f32 = 70.0;
-// When you set the `BANANA_SPAWN_TIMER_IN_SECONDS` to 0.5, a bug
-// occurs when you catch a banana at the top of the basket. The
-// other banana that has "just spawned" will disappear until the
-// next banana spawns. Should look into this more.
 pub const BANANA_SPAWN_TIMER_IN_SECONDS: f32 = 0.5;
 pub const BANANA_SPEED: f32 = 800.0;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ pub struct FallingObjectSpawnTimer {
 #[derive(Resource)]
 pub struct ImageCache {
     banana: Handle<Image>,
-    bunch_of_bananas: Handle<Image>
+    bunch_of_bananas: Handle<Image>,
 }
 
 #[derive(Resource)]
@@ -92,13 +92,10 @@ impl Default for FallingObjectSpawnTimer {
     }
 }
 
-pub fn load_and_cache_images(
-    mut commands: Commands,
-    asset_server: Res<AssetServer>,
-) {
+pub fn load_and_cache_images(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.insert_resource(ImageCache {
         banana: asset_server.load("sprites/banana.png"),
-        bunch_of_bananas: asset_server.load("sprites/bananabunch.png")
+        bunch_of_bananas: asset_server.load("sprites/bananabunch.png"),
     });
 }
 
@@ -152,9 +149,17 @@ pub fn spawn_falling_objects_over_time(
         let random_x = (random::<f32>() * bounds_width) + BOUND_SIZE;
 
         let (object_kind, points, texture) = if random::<f32>() < 0.1 {
-            (FallingObjectKind::BananaBunch, 5, image_cache.bunch_of_bananas.clone_weak())
+            (
+                FallingObjectKind::BananaBunch,
+                5,
+                image_cache.bunch_of_bananas.clone_weak(),
+            )
         } else {
-            (FallingObjectKind::Banana, 1, image_cache.banana.clone_weak())
+            (
+                FallingObjectKind::Banana,
+                1,
+                image_cache.banana.clone_weak(),
+            )
         };
 
         commands.spawn((


### PR DESCRIPTION
This PR adds an `ImageCache` resource that maintains a strong handle to the `banana.png` and `bananabunch.png` sprites. By doing so, this prevents these assets from unloading within a couple of frames of loading the same sprite. Click [here](https://docs.rs/bevy/latest/bevy/asset/struct.Handle.html) to learn more about strong and weak handles.

Fixes #6.

Credit: https://github.com/bevyengine/bevy/discussions/8288#discussioncomment-5502611